### PR TITLE
fhir tooling release via github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ out
 node_modules
 .vscode-test/
 *.vsix
-org.hl7.fhir.validator.jar
-org.hl7.fhir.publisher.jar
+*.jar
+yarn.lock
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "vscode-fhir-tools" extension will be documented in t
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+
+## [1.4.0] - 2020-07-28
+
+- Download url  for IG Publisher and Validator JAR changed to github
+
 ## [1.3.0] - 2020-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The Java validator and IG Publisher are updated frequently. You can update the t
 
 ## Requirements
 
-The resource validation use the official [FHIR validator](https://wiki.hl7.org/Using_the_FHIR_Validator 'Open hl7 wiki'). For this reason you must have JAVA jre installed and in your path.
+The resource validation use the official [FHIR validator](https://confluence.hl7.org/display/FHIR/Using+the+FHIR+Validator 'Open hl7 confluence'). For this reason you must have JAVA jre installed and in your path.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-fhir-tools",
 	"displayName": "FHIR tools",
 	"description": "",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"publisher": "Yannick-Lagger",
 	"author": {
 		"name": "Yannick Lagger",
@@ -111,7 +111,7 @@
 		"vscode-test": "^1.2.1"
 	},
 	"dependencies": {
-		"fhir": "^4.7.2",
+		"fhir": "^4.7.9",
 		"fhirpath": "^2.1.0"
 	}
 }

--- a/src/commands/fhirUpdateJavaTooling.ts
+++ b/src/commands/fhirUpdateJavaTooling.ts
@@ -11,16 +11,16 @@ let terminal: vscode.Terminal;
 const runUpdateJavaTooling = (context: vscode.ExtensionContext): vscode.Disposable => {
     return vscode.commands.registerCommand('extension.runUpdateJavaTooling', () => {
 
-        deleteJar(context, 'org.hl7.fhir.publisher.jar').then(resp => ig.downloadIGPublisher(context)).then(resp => {
+        deleteJar(context, 'publisher.jar').then(resp => ig.downloadIGPublisher(context)).then(resp => {
             if (!terminal) {
                 terminal = vscode.window.createTerminal(`Update Jar`);
             }
             terminal.show(true);
-            terminal.sendText(`java -jar ${path.join(context.extensionPath, 'org.hl7.fhir.publisher.jar')} --version`);
+            terminal.sendText(`java -jar ${path.join(context.extensionPath, 'publisher.jar')} --version`);
         }).then(
-            resp => deleteJar(context, 'org.hl7.fhir.validator.jar').then(resp => val.downloadJar(context)).then(resp => {
+            resp => deleteJar(context, 'validator_cli.jar').then(resp2 => val.downloadJar(context)).then(resp3 => {
                 terminal.show(true);
-                terminal.sendText(`java -jar ${path.join(context.extensionPath, 'org.hl7.fhir.validator.jar')}`);
+                terminal.sendText(`java -jar ${path.join(context.extensionPath, 'validator_cli.jar')}`);
             }));
     });
 };
@@ -37,7 +37,7 @@ const deleteJar = (context: vscode.ExtensionContext, file: string): Promise<bool
         }
         resolve(true);
     });
-}
+};
 
 export {
     runUpdateJavaTooling

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
 export const constants = {
-    donwloadJarUrl: 'https://storage.googleapis.com/ig-build'
+    downloadPublisherJarUrl: 'https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar',
+    downloadValidatorJarUrl: 'https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar'
 };


### PR DESCRIPTION
IGPublisher and the validator aren now distributed via github releases (see https://chat.fhir.org/#narrow/stream/179166-implementers/topic/latest.20version.20of.20the.20validator.3F). The code is adjusted to support that. Currently if expects the two redirects, this could maybe improved in a future version to check if really an update is needed.